### PR TITLE
Hoist the getModel function and allow it to be passed in

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ language: node_js
 node_js:
     - "0.10"
     - "0.12"
+    - "4"
+    - "stable"
 after_success: 'make report-coverage'

--- a/Makefile
+++ b/Makefile
@@ -53,12 +53,12 @@ githooks:
 
 .PHONY: lint
 lint: node_modules $(ESLINT) $(SRCS)
-	$(ESLINT) $(SRCS)
+	@$(ESLINT) $(SRCS)
 
 
 .PHONY: codestyle
 codestyle: node_modules $(JSCS) $(SRCS)
-	$(JSCS) $(SRCS)
+	@$(JSCS) $(SRCS)
 
 
 .PHONY: codestyle-fix
@@ -72,12 +72,12 @@ prepush: node_modules lint codestyle test
 
 .PHONY: test
 test: node_modules $(MOCHA) $(SRCS)
-	$(MOCHA) -R spec
+	@$(MOCHA) -R spec
 
 
 .PHONY: coverage
 coverage: node_modules $(ISTANBUL) $(SRCS)
-	$(ISTANBUL) cover $(_MOCHA) --report lcovonly -- -R spec
+	@$(ISTANBUL) cover $(_MOCHA) --report lcovonly -- -R spec
 
 
 .PHONY: report-coverage

--- a/lib/handlers/buildModels.js
+++ b/lib/handlers/buildModels.js
@@ -14,6 +14,7 @@ var errorTypes  = require('../errors');
  * Internal method for fetching any models that are resolved from
  * the model bucket.
  *
+ * @function getModel
  * @private
  * @param {Object} req request object
  * @param {Object} res response object

--- a/lib/handlers/buildModels.js
+++ b/lib/handlers/buildModels.js
@@ -3,12 +3,117 @@
 // external modules
 var _           = require('lodash');
 var vasync      = require('vasync');
+var assert      = require('assert-plus');
 
 // internal files
 var reqHelpers  = require('../reqHelpers');
 var logHelpers  = require('../logHelpers');
 var errorTypes  = require('../errors');
 
+/**
+ * Internal method for fetching any models that are resolved from
+ * the model bucket.
+ *
+ * @private
+ * @param {Object} req request object
+ * @param {Object} res response object
+ * @param {Object} model model object
+ * @param {Function} callback callback when fetch is done
+ * @returns {undefined}
+ */
+function getModel(req, res, model, callback) {
+    var log;
+
+    // get a req.log if available, or use the default.
+    // create a child logger off of it.
+    if (req.log) {
+        log = req.log.child({ component: 'buildModels' });
+        logHelpers.addSerializers(log);
+    } else {
+        // default logger already has serializers, no need to add.
+        log = logHelpers.getDefault();
+    }
+
+    // set the model on the request always, regardless of
+    // success or failure.
+    reqHelpers.setModel(req, model);
+
+    // preconfigure the model with other things we need.
+    // only populate the client if it's a model that requires fetching something
+    // from a remote host.
+    model.preConfigure(req, res, {
+        client: reqHelpers.getClient(req, model),
+        log: log
+    });
+
+    // log a debug, then go fetch it!
+    // also start req timers.
+    req.startHandlerTimer(
+        req._restifyConductor.timerNamePrefix + '-' + model.name
+    );
+    log.debug({ model: model }, 'Building model...');
+
+    model.get(function getModelComplete(reqErr, rawData) {
+
+        // log debug on completion
+        log.debug({ modelName: model.name }, 'Build complete!');
+        // stop the request timers
+        req.endHandlerTimer(
+            req._restifyConductor.timerNamePrefix + '-' + model.name
+        );
+
+        var finalErr;
+
+        // handle lower level errors first
+        if (reqErr) {
+
+            // handle 401s uniquely, check for status codes
+            if (rawData.statusCode === 401) {
+                finalErr = new errorTypes.UnauthorizedError(
+                    reqErr
+                );
+                // create a new error, log it, add it to model error state, return.
+                // push error in the errors array, and return
+                model.errors.push(finalErr);
+                return callback(finalErr, model);
+            } else if (_.isFunction(model.fallback)) {
+                // if we have a fallback function, attempt to use it.
+                log.info({
+                    name: model.name
+                }, 'attempting fallback mode!');
+
+                // run the function, expect consumers to set this.data
+                model.fallback();
+
+                // set the fallback mode flag to true
+                model.fallbackMode = true;
+
+                // in fallback mode, don't return on callback.
+                // attempt to go through regular flow
+            }
+        }
+
+        // if no lower level err, check validity.
+        if (model.isValid(rawData)) {
+
+            // if valid, save it!
+            model.data = rawData;
+
+            // do any munging if needed
+            model.postConfigure(req, res);
+
+            // success! return with no err.
+            return callback(null);
+        } else {
+            // if we failed validation, create a validation error, log it, return
+            finalErr = new errorTypes.ModelValidationError(
+                'model validation error for ' + model.name
+            );
+            model.errors.push(finalErr);
+            return callback(finalErr, model);
+        }
+    });
+}
 
 /**
  * a handler to build any models defined on the conductor.
@@ -16,16 +121,26 @@ var errorTypes  = require('../errors');
  * @function buildModelsWrapper
  * @param    {Array}     modelBucket a key we can use to look up a bucket
  *                                   of models defined on the conductor
+ * @param    {Function} modelFetcher function to run for fetching / creating
+ *                                   models. The function should accept req
+ *                                   as the first parameter, req as the
+ *                                   second, a models array as the third, and
+ *                                   a callback as the fourth.
  * @returns  {undefined}
  */
-function buildModelsWrapper(modelBucket) {
+function buildModelsWrapper(modelBucket, modelFetcher) {
+    assert.optionalFunc(modelFetcher, 'modelFetcher');
+
+    if (!modelFetcher) {
+        modelFetcher = getModel;
+    }
 
     return function buildModels(req, res, next) {
 
         var conductor = reqHelpers.getConductor(req);
         var models = conductor.createModels(req, res, modelBucket);
         var log;
-
+        var partialModel;
 
         // get a req.log if available, or use the default.
         // create a child logger off of it.
@@ -37,93 +152,13 @@ function buildModelsWrapper(modelBucket) {
             log = logHelpers.getDefault();
         }
 
+        partialModel = _.partial(modelFetcher, req, res);
 
-        // TODO: there's a restify bug here in req.timers.
+        // there's a restify bug here in req.timers.
         // if we call start/endHandlerTimer with the same name a second time,
         // it won't register, since req.timers is a map.
         vasync.forEachParallel({
-            func: function getModel(model, callback) {
-
-                // set the model on the request always, regardless of
-                // success or failure.
-                reqHelpers.setModel(req, model);
-
-                // preconfigure the model with other things we need.
-                // only populate the client if it's a model that requires fetching something
-                // from a remote host.
-                model.preConfigure(req, res, {
-                    client: reqHelpers.getClient(req, model),
-                    log: log
-                });
-
-                // log a debug, then go fetch it!
-                // also start req timers.
-                req.startHandlerTimer(
-                    req._restifyConductor.timerNamePrefix + '-' + model.name
-                );
-                log.debug({ model: model }, 'Building model...');
-
-                model.get(function getModelComplete(reqErr, rawData) {
-
-                    // log debug on completion
-                    log.debug({ modelName: model.name }, 'Build complete!');
-                    // stop the request timers
-                    req.endHandlerTimer(
-                        req._restifyConductor.timerNamePrefix + '-' + model.name
-                    );
-
-                    var finalErr;
-
-                    // handle lower level errors first
-                    if (reqErr) {
-
-                        // handle 401s uniquely, check for status codes
-                        if (rawData.statusCode === 401) {
-                            finalErr = new errorTypes.UnauthorizedError(
-                                reqErr
-                            );
-                            // create a new error, log it, add it to model error state, return.
-                            // push error in the errors array, and return
-                            model.errors.push(finalErr);
-                            return callback(finalErr, model);
-                        } else if (_.isFunction(model.fallback)) {
-                            // if we have a fallback function, attempt to use it.
-                            log.info({
-                                name: model.name
-                            }, 'attempting fallback mode!');
-
-                            // run the function, expect consumers to set this.data
-                            model.fallback();
-
-                            // set the fallback mode flag to true
-                            model.fallbackMode = true;
-
-                            // in fallback mode, don't return on callback.
-                            // attempt to go through regular flow
-                        }
-                    }
-
-                    // if no lower level err, check validity.
-                    if (model.isValid(rawData)) {
-
-                        // if valid, save it!
-                        model.data = rawData;
-
-                        // do any munging if needed
-                        model.postConfigure(req, res);
-
-                        // success! return with no err.
-                        return callback(null);
-                    } else {
-                        // if we failed validation, create a validation error, log it, return
-                        finalErr = new errorTypes.ModelValidationError(
-                            'model validation error for ' + model.name
-                        );
-                        model.errors.push(finalErr);
-                        return callback(finalErr, model);
-                    }
-                });
-            },
+            func: partialModel,
             inputs: models
         }, function vasyncComplete(err, results) {
 
@@ -153,14 +188,13 @@ function buildModelsWrapper(modelBucket) {
 
                 // log out context of failed models
                 log.error('all models built, but ' + failedModelNames.length +
-                   ' model(s) failed: ' + failedModelNames.join(', '));
+                          ' model(s) failed: ' + failedModelNames.join(', '));
 
                 // log out the stack trace for each individual failed model
                 _.forEach(modelErrs, function(modelErr, idx) {
                     log.error({ conductorModel: failedModels[idx] },
                               (idx + 1) + ' of ' + modelErrs.length +
-                            ' failed models: ' + failedModels[idx].name
-                    );
+                                  ' failed models: ' + failedModels[idx].name);
 
                     // x of y to be used in error msgs
                     log.error(modelErr);

--- a/lib/index.js
+++ b/lib/index.js
@@ -138,4 +138,5 @@ module.exports.handlers = {
 module.exports.getConductor = reqHelpers.getConductor;
 module.exports.getProps = reqHelpers.getProps;
 module.exports.getModels = reqHelpers.getModels;
+module.exports.setModel = reqHelpers.setModel;
 module.exports.shardConductor = reqHelpers.shardConductor;


### PR DESCRIPTION
I hoisted the getModel function out of the `forEachParallel` call so that a new function can be passed in if desired.
