### PR TITLE
Add ability to pass an object to installConductor, not just a string

### DIFF
--- a/example/demo.js
+++ b/example/demo.js
@@ -95,5 +95,10 @@ rc.get('/shard', shardConductor.shard, demoServer);
 rc.get('/shardText', shardConductor.shardText, demoServer);
 rc.get('/shardJson', shardConductor.shardJson, demoServer);
 
+// Object examples
+rc.get({path: '/object'}, simpleConductor, demoServer);
+rc.get({path: '/object1', flags: 'i'}, simpleConductor2, demoServer);
+rc.get({path: '/Object2'}, simpleConductor2, demoServer);
+rc.get({path: '/OBJECT3'}, simpleConductor2, demoServer);
 
 module.exports = demoServer;

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,18 +33,22 @@ var METHODS = [
  * @private
  * @function installConductor
  * @param   {String} method    get | post | head | put | del
- * @param   {String} urlPath   the path to install the conductor at
+ * @param   {String|Object}    opts the url of REST resource or
+ *                                  opts to pass to Restify
  * @param   {Object} server    a restify server object
  * @param   {Object} conductor a Conductor instance
  * @returns {undefined}
  */
-function installConductor(method, urlPath, server, conductor) {
+function installConductor(method, opts, server, conductor) {
 
     // assert params
     assert.string(method, 'method');
-    assert.string(urlPath, 'urlPath');
     assert.object(server, 'server');
     assert.equal(conductor instanceof Conductor, true);
+
+    if ( !opts || (typeof opts !== 'string' && typeof opts !== 'object')) {
+        return assert.fail('opts needs to be a string or object');
+    }
 
     var handlers = [];
     var applyArgs;
@@ -57,7 +61,7 @@ function installConductor(method, urlPath, server, conductor) {
     ]);
 
     // add the method to the top of the args
-    applyArgs = [urlPath].concat(handlers);
+    applyArgs = [opts].concat(handlers);
 
     // now install the route
     server[method].apply(server, applyArgs);
@@ -107,13 +111,14 @@ function createModel(options) {
 _.forEach(METHODS, function(method) {
     /**
      * programatically create wrapperis for Restify's server[method]
-     * @param   {String}    urlPath   the url of REST resource
+     * @param   {String|Object}    opts the url of REST resource or
+     *                                  opts to pass to Restify
      * @param   {Conductor} conductor a conductor instance
      * @param   {Object}    server    a restify server
      * @returns {undefined}
      */
-    var methodInstaller = function(urlPath, conductor, server) {
-        installConductor(method, urlPath, server, conductor);
+    var methodInstaller = function(opts, conductor, server) {
+        installConductor(method, opts, server, conductor);
     };
     methodInstaller.displayName = method;
 

--- a/test/ConductorSpec.js
+++ b/test/ConductorSpec.js
@@ -3,13 +3,68 @@
 
 'use strict';
 
-var _      = require('lodash');
-var assert = require('assert');
-var rc    = require('../lib');
-var Model  = require('../lib/models/Model');
+var _       = require('lodash');
+var assert  = require('assert');
+var rc      = require('../lib');
+var Model   = require('../lib/models/Model');
+var restify = require('restify');
 
 
 describe('Restify Conductor', function() {
+
+    describe('route installation', function() {
+        var server;
+        var conductor;
+
+        beforeEach(function() {
+            server = restify.createServer({
+                name: 'testing'
+            });
+            conductor = rc.createConductor({
+                name: 'test'
+            });
+        });
+
+        it('should add get route', function() {
+            rc.get('/foo', conductor, server);
+            assert.equal(_.keys(server.routes).length, 1);
+        });
+
+        it('should add all route types', function() {
+            var routeVerbs = [
+                'del',
+                'get',
+                'head',
+                'opts',
+                'post',
+                'put',
+                'patch'
+            ];
+            _.map(routeVerbs, function(verb) {
+                rc[verb]('/bar', conductor, server);
+            });
+
+            assert.equal(_.keys(server.routes).length, routeVerbs.length);
+        });
+
+        it('should accept an object for the route', function() {
+            rc.get({path: '/path'}, conductor, server);
+            assert.equal(_.keys(server.routes).length, 1);
+        });
+
+        it('should throw when no object or string present', function() {
+            assert.throws(function() {
+                rc.get(null, conductor, server);
+            });
+            assert.throws(function() {
+                rc.get(false, conductor, server);
+            });
+            assert.throws(function() {
+                rc.get(1, conductor, server);
+            });
+            assert.equal(_.keys(server.routes).length, 0);
+        });
+    });
 
     describe('constructor tests', function() {
 

--- a/test/IntegrationSpec.js
+++ b/test/IntegrationSpec.js
@@ -275,4 +275,39 @@ describe('Integration tests using the demo app', function() {
         });
     });
 
+    describe('object', function() {
+        it('should return hello world', function(done) {
+            stringClient.get('/object', function(err, req, res, data) {
+                assert.ifError(err);
+                assert.equal(data, 'hello world!');
+                done();
+            });
+        });
+
+        it('should return hello world and conductor name', function(done) {
+            stringClient.get('/Object1', function(err, req, res, data) {
+                assert.ifError(err);
+                assert.equal(data, 'hello world: simpleConductor2!');
+                done();
+            });
+        });
+
+        it('should return hello world, conductor name', function(done) {
+            stringClient.get('/Object2', function(err, req, res, data) {
+                assert.ifError(err);
+                assert.equal(data, 'hello world: simpleConductor2!');
+                done();
+            });
+        });
+
+        it('should return a 404', function(done) {
+            stringClient.get('/object3', function(err, req, res, data) {
+                assert.ok(err);
+                assert.equal(res.statusCode, 404);
+                assert.equal(data, '/object3 does not exist');
+                done();
+            });
+        });
+
+    });
 });


### PR DESCRIPTION
Allow passing an object or string when installing a conductor.

Fixes #20 
