### PR TITLE
Props object

### DIFF
--- a/lib/Conductor.js
+++ b/lib/Conductor.js
@@ -135,10 +135,7 @@ function Conductor(config) {
          * @param   {Object} inheritedProps the initial props given to the conductor
          * @returns {Object}
          */
-        propsFn: config.props || function setDefaultProps(inheritedProps) {
-            return inheritedProps || {};
-        },
-
+        propsFn: null,
         /**
          * key/val pair where val is an array of functions returning instances
          * of Models. keys allow you to specify multiple buckets of models. e.g.,
@@ -152,11 +149,19 @@ function Conductor(config) {
         models: config.models || {}
     };
 
-    // If props isn't a function and is instead an object, wrap it
-    if (_.isPlainObject(this._config.propsFn) &&
-        _.isPlainObject(config.props)) {
+    // This will be the normal case, devs should pass a function to handle
+    // props
+    if (_.isFunction(config.props)) {
+        this._config.propsFn = config.props;
+    } else if (_.isPlainObject(config.props)) {
+        // If props isn't a function and is instead an object, wrap it
         this._config.propsFn = function setWrapperProps() {
             return config.props;
+        };
+    } else {
+        // Wrapper for generating default props for a conductor
+        this._config.propsFn = function setDefaultProps(inheritedProps) {
+            return inheritedProps || {};
         };
     }
 

--- a/lib/Conductor.js
+++ b/lib/Conductor.js
@@ -168,7 +168,7 @@ function Conductor(config) {
     // Determine if the propsFn passed is now a proper function after
     // being wrapped or not. If it wasn't a plain object it won't now be
     // wrapped by a function so this assert will fail
-    assert.optionalFunc(this._config.propsFn, 'config.props');
+    assert.func(this._config.propsFn, 'config.props');
 
     // first, sort the dependencies.
     // this call is recursive, will walk through all deps and sort

--- a/lib/Conductor.js
+++ b/lib/Conductor.js
@@ -33,7 +33,6 @@ function Conductor(config) {
 
     // assert optional
     assert.optionalArrayOfObject(config.deps, 'config.deps');
-    assert.optionalFunc(config.props, 'config.props');
 
     // since models and handlers can be either objects or arrays, how do we
     // assert them? optionalArrayOrObject?
@@ -153,6 +152,18 @@ function Conductor(config) {
         models: config.models || {}
     };
 
+    // If props isn't a function and is instead an object, wrap it
+    if (_.isPlainObject(this._config.propsFn) &&
+        _.isPlainObject(config.props)) {
+        this._config.propsFn = function setWrapperProps() {
+            return config.props;
+        };
+    }
+
+    // Determine if the propsFn passed is now a proper function after
+    // being wrapped or not. If it wasn't a plain object it won't now be
+    // wrapped by a function so this assert will fail
+    assert.optionalFunc(this._config.propsFn, 'config.props');
 
     // first, sort the dependencies.
     // this call is recursive, will walk through all deps and sort

--- a/test/ConductorSpec.js
+++ b/test/ConductorSpec.js
@@ -401,6 +401,16 @@ describe('Restify Conductor', function() {
             assert.deepEqual(conductorA.getProps('letters'), { a: 1 });
             assert.deepEqual(conductorB.getProps('letters'), { a: 1, b: 2 });
         });
+
+        it('gh-8 should allow props to be an object', function() {
+            var conductorA = rc.createConductor({
+                name: 'A',
+                props: {
+                    foo: 'bar'
+                }
+            });
+            assert.equal(conductorA.getProps('foo'), 'bar');
+        });
     });
 
     describe('model tests', function() {


### PR DESCRIPTION
Allows devs to pass in a plain object not just a function to config.props.

Fixes #8 
