### PR TITLE
Add friendly error for Handler errors and catch non-functions in handler blocks

### DIFF
--- a/lib/Conductor.js
+++ b/lib/Conductor.js
@@ -26,6 +26,7 @@ var helpers     = require('./helpers');
  * @param {Object} [config.handlers] an object or array of handlers
  */
 function Conductor(config) {
+    var self = this;
 
     // assert required options
     assert.object(config, 'config');
@@ -177,6 +178,19 @@ function Conductor(config) {
 
     // now that dependencies are sorted, merge all the props, handlers, models.
     this._mergeDeps();
+
+    // this._handlers is an array of handler arrays, so loop in to the
+    // lowest level to check for each one being a function
+    _.map(this._handlers, function(handlers) {
+        _.map(handlers, function(handler) {
+            if (!_.isFunction(handler)) {
+                assert.func(
+                    handler,
+                    'handler is not a function in conductor: ' + self.name
+                );
+            }
+        });
+    });
 
     // lastly, sort the finalized handler keys, after we've created all the oban
     // props.  do this now so we don't have to do it at run time to determine

--- a/test/ConductorSpec.js
+++ b/test/ConductorSpec.js
@@ -85,6 +85,17 @@ describe('Restify Conductor', function() {
         });
 
 
+        it('should throw if a handler isn\'t a function in constructor',
+           function() {
+            assert.throws(function() {
+                rc.createConductor({
+                    name: 'A',
+                    handlers: {5:[ [_.noop] ] }
+                });
+            }, 'throw an error with nested handlers');
+        });
+
+
         it('should create internal props using passed in config', function() {
             var conductorA = rc.createConductor({
                     name: 'A',

--- a/test/runSpec.js
+++ b/test/runSpec.js
@@ -1,0 +1,51 @@
+'use strict';
+
+var assert = require('assert-plus');
+var _ = require('lodash');
+var rc = require('../lib');
+var runHandlers = require('../lib/handlers/run')();
+
+function mockReq(conductor) {
+    return {
+        _restifyConductor: {
+            conductor: conductor
+        },
+        startHandlerTimer: _.noop,
+        endHandlerTimer: _.noop
+    };
+}
+
+function createConductor(handlers) {
+    return rc.createConductor({
+        name: 'A',
+        handlers: {
+            0: handlers
+        }
+    });
+}
+
+describe('Restify Conductor run', function() {
+    var conductorA;
+    var calledOnce = false;
+    var calledOnceHandler = function(req, res, next) {
+        calledOnce = true;
+        next();
+    };
+    var handlers = [calledOnceHandler];
+
+    beforeEach(function() {
+        conductorA = createConductor(handlers);
+    });
+
+
+    it('should run the first handler block', function(done) {
+        runHandlers(
+            mockReq(conductorA),
+            {},
+            function() {
+                assert.ok(calledOnce);
+                done();
+            }
+        );
+    });
+});


### PR DESCRIPTION
Stop execution of a Conductor's handlers if one of them isn't a function (possibly a nested array). Also, return a much more helpful error message so that devs can diagnose where the problem lies.

PTAL @DonutEspresso 

Fixes #13
