### PR TITLE
Add createConductorHandlers function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -55,10 +55,7 @@ function installConductor(method, opts, server, conductor) {
 
     // add a 'universal' conductor to beginning of handler stack.
     // save the restify conductor on the request.
-    handlers.push([
-        internalHandlers.init(conductor),
-        internalHandlers.run()
-    ]);
+    handlers.push(createConductorHandlers(conductor));
 
     // add the method to the top of the args
     applyArgs = [opts].concat(handlers);
@@ -71,7 +68,6 @@ function installConductor(method, opts, server, conductor) {
 //------------------------------------------------------------------------------
 // public methods
 //------------------------------------------------------------------------------
-
 
 /**
  * wrapper function for creating conductors
@@ -107,6 +103,19 @@ function createModel(options) {
     }
 }
 
+/**
+ * Create a middleware chain that executes a specific conductor
+ * @public
+ * @function createConductorHandlers
+ * @param {Object} conductor a Conductor instance
+ * @returns {Function[]}
+ */
+function createConductorHandlers(conductor) {
+    return [
+        internalHandlers.init(conductor),
+        internalHandlers.run()
+    ];
+}
 
 _.forEach(METHODS, function(method) {
     /**
@@ -129,6 +138,7 @@ _.forEach(METHODS, function(method) {
 // specific classes and wrappers
 module.exports.createConductor = createConductor;
 module.exports.createModel = createModel;
+module.exports.createConductorHandlers = createConductorHandlers;
 
 // exposed handlers, only expose a subset of all internal handlers.
 module.exports.handlers = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -111,6 +111,7 @@ function createModel(options) {
  * @returns {Function[]}
  */
 function createConductorHandlers(conductor) {
+    assert.equal(conductor instanceof Conductor, true);
     return [
         internalHandlers.init(conductor),
         internalHandlers.run()

--- a/test/ConductorSpec.js
+++ b/test/ConductorSpec.js
@@ -25,44 +25,77 @@ describe('Restify Conductor', function() {
             });
         });
 
-        it('should add get route', function() {
-            rc.get('/foo', conductor, server);
-            assert.equal(_.keys(server.routes).length, 1);
+        describe('with rc verbs', function () {
+
+            it('should add get route', function() {
+                rc.get('/foo', conductor, server);
+                assert.equal(_.keys(server.routes).length, 1);
+            });
+
+            it('should add all route types', function() {
+                var routeVerbs = [
+                    'del',
+                    'get',
+                    'head',
+                    'opts',
+                    'post',
+                    'put',
+                    'patch'
+                ];
+                _.map(routeVerbs, function(verb) {
+                    rc[verb]('/bar', conductor, server);
+                });
+
+                assert.equal(_.keys(server.routes).length, routeVerbs.length);
+            });
+
+            it('should accept an object for the route', function() {
+                rc.get({path: '/path'}, conductor, server);
+                assert.equal(_.keys(server.routes).length, 1);
+            });
+
+            it('should throw when no object or string present', function() {
+                assert.throws(function() {
+                    rc.get(null, conductor, server);
+                });
+                assert.throws(function() {
+                    rc.get(false, conductor, server);
+                });
+                assert.throws(function() {
+                    rc.get(1, conductor, server);
+                });
+                assert.equal(_.keys(server.routes).length, 0);
+            });
         });
 
-        it('should add all route types', function() {
-            var routeVerbs = [
-                'del',
-                'get',
-                'head',
-                'opts',
-                'post',
-                'put',
-                'patch'
-            ];
-            _.map(routeVerbs, function(verb) {
-                rc[verb]('/bar', conductor, server);
+        describe('with createConductorHandler', function() {
+
+            it('should add get route', function() {
+                server.get('/foo', rc.createConductorHandlers(conductor));
+                assert.equal(_.keys(server.routes).length, 1);
             });
 
-            assert.equal(_.keys(server.routes).length, routeVerbs.length);
-        });
+            it('should add all route types', function() {
+                var routeVerbs = [
+                    'del',
+                    'get',
+                    'head',
+                    'opts',
+                    'post',
+                    'put',
+                    'patch'
+                ];
+                _.map(routeVerbs, function(verb) {
+                    server[verb]('/bar', rc.createConductorHandlers(conductor));
+                });
 
-        it('should accept an object for the route', function() {
-            rc.get({path: '/path'}, conductor, server);
-            assert.equal(_.keys(server.routes).length, 1);
-        });
+                assert.equal(_.keys(server.routes).length, routeVerbs.length);
+            });
 
-        it('should throw when no object or string present', function() {
-            assert.throws(function() {
-                rc.get(null, conductor, server);
+            it('should accept an object for the route', function() {
+                server.get({path: '/path'}, rc.createConductorHandlers(conductor));
+                assert.equal(_.keys(server.routes).length, 1);
             });
-            assert.throws(function() {
-                rc.get(false, conductor, server);
-            });
-            assert.throws(function() {
-                rc.get(1, conductor, server);
-            });
-            assert.equal(_.keys(server.routes).length, 0);
         });
     });
 


### PR DESCRIPTION
Expose a `createConductorHandlers` method to build a middleware chain without registering it directly to the server. This makes conductors usable as just a middleware chain rather than only as a route on a Restify server.

You could imagine this being used in this way:

```
import { createConductorHandlers } from 'restify-conductor'

server.get('/myPath', createConductorHandlers(myConductor))
```