### PR TITLE
Fix broken tests

### DIFF
--- a/example/models/ip.js
+++ b/example/models/ip.js
@@ -14,6 +14,7 @@ var rc = require('../../lib/');
 module.exports = rc.createModel({
     name: 'ip',
     host: 'jsonip.com',
+    secure: true,
     isValid: function(data) {
         // validate the payload coming back.
         return (data.hasOwnProperty('ip') &&

--- a/example/models/posts.js
+++ b/example/models/posts.js
@@ -15,15 +15,10 @@ module.exports = rc.createModel({
     name: 'posts',
     host: 'jsonplaceholder.typicode.com',
     url: '/posts',
-    qs: {
-        userId: 1
-    },
     before: function(req, res) {
         // if the user passed in something as a query param
         // to be hashed, used that instead!
-        if (req.query.userId) {
-            this.qs.userId = req.query.userId;
-        }
+        this.qs.userId = req.query.userId || 1;
     },
     isValid: function(data) {
         // validate the payload coming back.

--- a/test/IntegrationSpec.js
+++ b/test/IntegrationSpec.js
@@ -161,7 +161,7 @@ describe('Integration tests using the demo app', function() {
                 // assert posts model
                 assert.isArray(data.posts);
                 _.forEach(data.posts, function(post) {
-                    assert.equal(post.userId, 2);
+                    assert.equal(post.userId, 1);
                     assert.isNumber(post.id);
                     assert.isString(post.title);
                     assert.isString(post.body);


### PR DESCRIPTION
This PR fixes the currently broken tests:

 * `http://jsonip.com` now redirects to `https://jsonip.com` which was causing the `ip` model to fail.
 * The query string for the `posts` model was persisting between model calls. There was a test that was checking the wrong value because of this which I fixed. This is actually seems like a bigger issue, but I don't understand what's happening under the hood.