### PR TITLE
Upgrade to latest Restify packages

### DIFF
--- a/example/demo.js
+++ b/example/demo.js
@@ -49,8 +49,9 @@ var demoServer = restify.createServer({
 // set up auditing, error handling
 demoServer.on(
     'after',
-    restify.auditLogger({
-        log: logger.child({ component: 'restify-audit' })
+    restify.plugins.auditLogger({
+        log: logger.child({ component: 'restify-audit' }),
+        event: 'after'
     })
 );
 
@@ -67,9 +68,9 @@ demoServer.on('uncaughtException', function(req, res, route, err) {
 });
 
 // set up server
-demoServer.pre(restify.sanitizePath());
-demoServer.use(restify.queryParser());
-demoServer.use(restify.requestLogger());
+demoServer.pre(restify.plugins.pre.sanitizePath());
+demoServer.use(restify.plugins.queryParser());
+demoServer.use(restify.plugins.requestLogger());
 
 // simple examples
 rc.get('/simple', simpleConductor, demoServer);
@@ -102,7 +103,7 @@ rc.get('/shardJson', shardConductor.shardJson, demoServer);
 
 // Object examples
 rc.get({ path: '/object' }, simpleConductor, demoServer);
-rc.get({ path: '/object1', flags: 'i' }, simpleConductor2, demoServer);
+rc.get({ path: '/Object1' }, simpleConductor2, demoServer);
 rc.get({ path: '/Object2' }, simpleConductor2, demoServer);
 rc.get({ path: '/OBJECT3' }, simpleConductor2, demoServer);
 

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -2,9 +2,9 @@
 
 var errors = require('restify-errors');
 
-errors.makeConstructor('ModelValidationError');
-errors.makeConstructor('ModelRequestError');
-errors.makeConstructor('EmptyHandlersError');
-errors.makeConstructor('ShardError');
-
-module.exports = errors;
+module.exports = {
+    ModelValidationError: errors.makeConstructor('ModelValidationError'),
+    ModelRequestError: errors.makeConstructor('ModelRequestError'),
+    EmptyHandlersError: errors.makeConstructor('EmptyHandlersError'),
+    ShardError: errors.makeConstructor('ShardError')
+};

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
     "bunyan": "^1.4.0",
     "immutable": "^3.7.4",
     "lodash": "^4.17.5",
-    "restify": "^4.0.3",
-    "restify-clients": "^1.1.0",
-    "restify-errors": "^3.0.0",
+    "restify": "^7.2.1",
+    "restify-clients": "^2.5.2",
+    "restify-errors": "^6.1.1",
     "toposort-class": "^0.3.1",
     "urijs": "^1.17.0",
     "vasync": "^1.6.3"

--- a/test/ConductorSpec.js
+++ b/test/ConductorSpec.js
@@ -26,7 +26,7 @@ describe('Restify Conductor', function() {
         describe('with rc verbs', function() {
             it('should add get route', function() {
                 rc.get('/foo', conductor, server);
-                assert.equal(_.keys(server.routes).length, 1);
+                assert.equal(_.keys(server.router.getRoutes()).length, 1);
             });
 
             it('should add all route types', function() {
@@ -43,12 +43,12 @@ describe('Restify Conductor', function() {
                     rc[verb]('/bar', conductor, server);
                 });
 
-                assert.equal(_.keys(server.routes).length, routeVerbs.length);
+                assert.equal(_.keys(server.router.getRoutes()).length, routeVerbs.length);
             });
 
             it('should accept an object for the route', function() {
                 rc.get({ path: '/path' }, conductor, server);
-                assert.equal(_.keys(server.routes).length, 1);
+                assert.equal(_.keys(server.router.getRoutes()).length, 1);
             });
 
             it('should throw when no object or string present', function() {
@@ -61,14 +61,14 @@ describe('Restify Conductor', function() {
                 assert.throws(function() {
                     rc.get(1, conductor, server);
                 });
-                assert.equal(_.keys(server.routes).length, 0);
+                assert.equal(_.keys(server.router.getRoutes()).length, 0);
             });
         });
 
         describe('with createConductorHandler', function() {
             it('should add get route', function() {
                 server.get('/foo', rc.createConductorHandlers(conductor));
-                assert.equal(_.keys(server.routes).length, 1);
+                assert.equal(_.keys(server.router.getRoutes()).length, 1);
             });
 
             it('should add all route types', function() {
@@ -85,7 +85,7 @@ describe('Restify Conductor', function() {
                     server[verb]('/bar', rc.createConductorHandlers(conductor));
                 });
 
-                assert.equal(_.keys(server.routes).length, routeVerbs.length);
+                assert.equal(_.keys(server.router.getRoutes()).length, routeVerbs.length);
             });
 
             it('should accept an object for the route', function() {
@@ -93,7 +93,7 @@ describe('Restify Conductor', function() {
                     { path: '/path' },
                     rc.createConductorHandlers(conductor)
                 );
-                assert.equal(_.keys(server.routes).length, 1);
+                assert.equal(_.keys(server.router.getRoutes()).length, 1);
             });
         });
     });

--- a/test/IntegrationSpec.js
+++ b/test/IntegrationSpec.js
@@ -80,7 +80,7 @@ describe('Integration tests using the demo app', function() {
             client.get('/props?search=foo', function(err, req, res, data) {
                 assert.ok(err);
                 assert.equal(res.statusCode, 400);
-                assert.equal(data.code, 'BadRequestError');
+                assert.equal(data.code, 'BadRequest');
                 assert.equal(data.message, 'query not allowed!');
                 done();
             });
@@ -98,7 +98,7 @@ describe('Integration tests using the demo app', function() {
             client.get('/props2?search=baz', function(err, req, res, data) {
                 assert.ok(err);
                 assert.equal(res.statusCode, 400);
-                assert.equal(data.code, 'BadRequestError');
+                assert.equal(data.code, 'BadRequest');
                 assert.equal(data.message, 'query not allowed!');
                 done();
             });
@@ -197,7 +197,7 @@ describe('Integration tests using the demo app', function() {
             client.get('/inherit?search=foo', function(err, req, res, data) {
                 assert.ok(err);
                 assert.equal(res.statusCode, 400);
-                assert.equal(data.code, 'BadRequestError');
+                assert.equal(data.code, 'BadRequest');
                 assert.equal(data.message, 'query not allowed!');
                 done();
             });
@@ -220,7 +220,7 @@ describe('Integration tests using the demo app', function() {
             ) {
                 assert.ok(err);
                 assert.equal(res.statusCode, 400);
-                assert.equal(data.code, 'BadRequestError');
+                assert.equal(data.code, 'BadRequest');
                 assert.equal(data.message, 'query not allowed!');
                 done();
             });
@@ -235,7 +235,7 @@ describe('Integration tests using the demo app', function() {
             ) {
                 assert.ok(err);
                 assert.equal(res.statusCode, 400);
-                assert.equal(data.code, 'BadRequestError');
+                assert.equal(data.code, 'BadRequest');
                 assert.equal(data.message, 'query not allowed!');
                 done();
             });
@@ -362,7 +362,7 @@ describe('Integration tests using the demo app', function() {
             stringClient.get('/object3', function(err, req, res, data) {
                 assert.ok(err);
                 assert.equal(res.statusCode, 404);
-                assert.equal(data, '/object3 does not exist');
+                assert.equal(data, '{"code":"ResourceNotFound","message":"/object3 does not exist"}');
                 done();
             });
         });


### PR DESCRIPTION
This PR updates all of the Restify dependencies to their latest versions. Only minor changes were necessary. Mostly just the tests and examples needed to be updated, but there is also a change in how Restify errors is used, so this should still likely be a major semver bump when released.