### PR TITLE
Don't bail if logger doesn't support `addSerializers` (such as pino)

### DIFF
--- a/lib/logHelpers.js
+++ b/lib/logHelpers.js
@@ -81,6 +81,9 @@ function child(name) {
  * @returns  {void}
  */
 function addSerializers(log) {
+    if (!log.addSerializers) {
+        return;
+    }
     log.addSerializers({
         conductorModel: function(model) {
             if (!model) {


### PR DESCRIPTION
Fixes NPE when using pino instead of bunyan

FYI @mridgway @DonutEspresso 

@DonutEspresso would you mind merging and releasing a patch version?