### PR TITLE
Remove model failure logging

### DIFF
--- a/lib/handlers/buildModels.js
+++ b/lib/handlers/buildModels.js
@@ -184,30 +184,6 @@ function buildModelsWrapper(modelBucket, modelFetcher) {
                             failedModels.push(op.result);
                         }
                     });
-
-                    // log out context of failed models
-                    log.error(
-                        'all models built, but ' +
-                            failedModelNames.length +
-                            ' model(s) failed: ' +
-                            failedModelNames.join(', ')
-                    );
-
-                    // log out the stack trace for each individual failed model
-                    _.forEach(modelErrs, function(modelErr, idx) {
-                        log.error(
-                            { conductorModel: failedModels[idx] },
-                            idx +
-                                1 +
-                                ' of ' +
-                                modelErrs.length +
-                                ' failed models: ' +
-                                failedModels[idx].name
-                        );
-
-                        // x of y to be used in error msgs
-                        log.error(modelErr);
-                    });
                 }
 
                 // we actually don't want a failed model to force an error page.


### PR DESCRIPTION
Remove model failure logging.  This is an application concern, and is prone to logging out data that the application may not want in the logs.